### PR TITLE
角色列表所有功能增加完毕，（新增角色）（修改权限）（查询角色权限）

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,12 +69,12 @@
             <version>1.2.55</version>
         </dependency>
 
-        <!--<dependency>-->
-            <!--<groupId>com.google.code.gson</groupId>-->
-            <!--<artifactId>gson</artifactId>-->
-            <!--<version>2.6.2</version>-->
-            <!--<scope>compile</scope>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.6.2</version>
+            <scope>compile</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.qcloud</groupId>
@@ -91,19 +91,14 @@
         <!--Shiro权限认证 qyy-->
         <dependency>
             <groupId>org.apache.shiro</groupId>
-            <artifactId>shiro-core</artifactId>
+            <artifactId>shiro-spring</artifactId>
             <version>1.4.0</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github.theborakompanioni</groupId>
-            <artifactId>thymeleaf-extras-shiro</artifactId>
-            <version>1.2.1</version>
-        </dependency>
-        <dependency>
             <groupId>net.mingsoft</groupId>
             <artifactId>shiro-freemarker-tags</artifactId>
-            <version>0.1</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!--腾讯短信认证 qyy-->

--- a/src/main/java/cn/lanhuhebi/elderly_group/config/ShiroConfig.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/config/ShiroConfig.java
@@ -2,8 +2,11 @@ package cn.lanhuhebi.elderly_group.config;
 
 import cn.lanhuhebi.elderly_group.util.MyRealm;
 import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.spring.security.interceptor.AuthorizationAttributeSourceAdvisor;
 import org.apache.shiro.spring.web.ShiroFilterFactoryBean;
 import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
+import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
@@ -32,8 +35,13 @@ public class ShiroConfig {
         filterMap.put("/js/**", "anon");
         filterMap.put("/favicon.ico", "anon");
 
+        //测试权限
+        filterMap.put("/test", "anon");
+        filterMap.put("/doAuth", "anon");
+
         //authc:所有url都必须认证通过才可以访问; anon:所有url都都可以匿名访问,先配置anon再配置authc。
         filterMap.put("/","anon");
+
         filterMap.put("/doLogin","anon");
         //<!-- 过滤链定义，从上向下顺序执行，一般将/**放在最为下边 -->:这是一个坑呢，一不小心代码就不好使了;
         filterMap.put("/**","authc");
@@ -41,8 +49,10 @@ public class ShiroConfig {
         bean.setLoginUrl("/");
         //successUrl：登录成功默认跳转页面，不配置则跳转至”/”，可以不配置，直接通过代码进行处理。
         bean.setSuccessUrl("/info");
+
         //unauthorizedUrl：没有权限默认跳转的页面，登录的用户访问了没有被授权的资源自动跳转到的页面。
-        bean.setUnauthorizedUrl("/");
+        bean.setUnauthorizedUrl("/notauth");
+
         bean.setFilterChainDefinitionMap(filterMap);
         return bean;
     }
@@ -54,5 +64,26 @@ public class ShiroConfig {
         securityManager.setRealm(new MyRealm());
         return securityManager;
     }
+
+
+
+    /**
+     * 开启aop注解支持
+     */
+    @Bean
+    public AuthorizationAttributeSourceAdvisor authorizationAttributeSourceAdvisor(SecurityManager securityManager){
+        AuthorizationAttributeSourceAdvisor attributeSourceAdvisor = new AuthorizationAttributeSourceAdvisor();
+        //设置安全管理器
+        attributeSourceAdvisor.setSecurityManager(securityManager);
+        return attributeSourceAdvisor;
+    }
+    @Bean
+    @ConditionalOnMissingBean
+    public DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator() {
+        DefaultAdvisorAutoProxyCreator defaultAAP = new DefaultAdvisorAutoProxyCreator();
+        defaultAAP.setProxyTargetClass(true);
+        return defaultAAP;
+    }
+
 
 }

--- a/src/main/java/cn/lanhuhebi/elderly_group/config/ShiroTagFreeMarkerConfig.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/config/ShiroTagFreeMarkerConfig.java
@@ -1,0 +1,19 @@
+package cn.lanhuhebi.elderly_group.config;
+
+import com.jagregory.shiro.freemarker.ShiroTags;
+import freemarker.template.Configuration;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ShiroTagFreeMarkerConfig implements InitializingBean {
+    @Autowired
+    private Configuration configuration;
+
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        configuration.setSharedVariable("shiro", new ShiroTags());
+    }
+}

--- a/src/main/java/cn/lanhuhebi/elderly_group/controller/PersonnelController.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/controller/PersonnelController.java
@@ -133,6 +133,11 @@ public class PersonnelController {
         return "redirect:/listPersonnels";
     }
 
+    /**
+     * 判断用具是否重复
+     * @param preRoleId
+     * @return
+     */
     @PostMapping(value = "/ajaxGetRole")
     @ResponseBody
     public Integer ajaxGetRole(Integer preRoleId){

--- a/src/main/java/cn/lanhuhebi/elderly_group/controller/QyyController.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/controller/QyyController.java
@@ -1,40 +1,38 @@
 package cn.lanhuhebi.elderly_group.controller;
 
-import cn.lanhuhebi.elderly_group.model.pojo.Personnel;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.authc.IncorrectCredentialsException;
 import org.apache.shiro.authc.UnknownAccountException;
 import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.apache.shiro.subject.Subject;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.servlet.http.HttpSession;
 
 /**
- * 登录
- * 除了登录页面“/” 、执行登录页面"/doLogin" shiro都拦截判断用户是否登录
- * 暂时没写权限认证
- * /logout 是shiro 做好的退出方法
+ * 以后可以删除
  */
 @Controller
-public class loginController {
+public class QyyController {
 
-    /**
-     * 去登录页面
-     *
-     * @return
-     */
-    @GetMapping(value = "/")
-    public String toLogin() {
+    @RequiresRoles(value = "1")
+    @RequestMapping("/testShiro")
+    public String testShiro(){
         return "login";
     }
 
+    @RequestMapping("/test")
+    public String textAuth(){
+        return "role/auth";
+    }
 
-    @PostMapping(value = "/doLogin")
+
+    @PostMapping(value = "/doAuth")
     public String doLogin(RedirectAttributes redirectAttributes,
                           @RequestParam(value = "account") String account,
                           @RequestParam(value = "password") String password, HttpSession session) {
@@ -50,22 +48,11 @@ public class loginController {
             redirectAttributes.addFlashAttribute("msg", "密码不正确");
         }
         if (subject.isAuthenticated()) {
-           if(subject.isPermitted("46")||subject.isPermitted("47")|| subject.isPermitted("48")||subject.isPermitted("49")
-                    ||subject.isPermitted("50")
-                ||subject.isPermitted("51")){
-                //将员工对象传给页面
-                Personnel personnel = (Personnel) subject.getPrincipal();
-                //将员工对象从Shiro内取出然后传给页面
-                session.setAttribute("personnel", personnel);
-                //登录成功
-                return "redirect:/info";
-            }else{
-                return "redirect:/notauth";
-            }
+            return "testAuto";
         } else {
             token.clear();
             //登录失败
-            return "redirect:/";
+            return "redirect:/test";
         }
     }
 

--- a/src/main/java/cn/lanhuhebi/elderly_group/controller/RoleController.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/controller/RoleController.java
@@ -1,0 +1,94 @@
+package cn.lanhuhebi.elderly_group.controller;
+
+import cn.lanhuhebi.elderly_group.model.pojo.Auth;
+import cn.lanhuhebi.elderly_group.service.RoleService;
+import com.google.gson.Gson;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import javax.servlet.http.HttpSession;
+import java.util.List;
+import java.util.Set;
+
+@Controller
+public class RoleController {
+
+    @Autowired
+    private RoleService roleService;
+
+    /**
+     * 去角色列表
+     * @return
+     */
+    @GetMapping(value = "/tolistrole")
+    public String tolistrole(Model model){
+        model.addAttribute("roles",roleService.getListRoleAndAuth());
+        return "role/listrole";
+    }
+
+    /**
+     * 执行新增角色方法
+     * @param roleName
+     * @param redirectAttributes
+     * @return
+     */
+    @PostMapping(value = "/doAddRole")
+    public String doAddRole(String roleName, RedirectAttributes redirectAttributes){
+        if(roleService.addRole(roleName)){
+            redirectAttributes.addFlashAttribute("addmsg","添加角色成功");
+        }else {
+            redirectAttributes.addFlashAttribute("addmsg","添加角色失败");
+        }
+        return "redirect:/tolistrole";
+    }
+
+    /**
+     * ajax判断角色名是否重复
+     * @param roleName
+     * @return
+     */
+    @PostMapping(value = "/ajaxGetRoleByRoleName")
+    @ResponseBody
+    public boolean ajaxGetRoleByRoleName(String roleName){
+        return roleService.getRoleByroleName(roleName);
+    }
+
+    //去菜单及权限配置
+    @GetMapping("/toUpdateAuth")
+    public String toUpdateAuth(Integer rlId, Model model, String rlName){
+        model.addAttribute("rlId",rlId);
+        model.addAttribute("rlName",rlName);
+        return "role/updateAuth";
+    }
+
+    //获得当前角色所有权限
+    @PostMapping("/ajaxgetSysRoleAuthByRoleId")
+    @ResponseBody
+    public String ajaxgetSysRoleAuthByRoleId(Integer rlId){
+        List<Auth> auths = roleService.getSysRoleAuthByRoleId(rlId);
+        Gson gson = new Gson();
+        return gson.toJson(auths);
+    }
+    //执行修改方法
+    @PostMapping(value = "/doUpdateAuth")
+    public String doUpdateAuth(@RequestParam(value = "authId",required = false) Set<Integer> authId, String rlName,Integer roleId,RedirectAttributes attributes){
+        if(authId.size()>0){
+            Integer[] integers = roleService.updateAUthsByRoleId(authId, roleId);
+            attributes.addFlashAttribute("addauthmsg",integers[0]);
+            attributes.addFlashAttribute("delauthmsg",integers[1]);
+            attributes.addFlashAttribute("rlName",rlName);
+        }
+        return "redirect:/tolistrole";
+    }
+    //如果没有权限执行这个方法，返回登录页面
+    @RequestMapping("/notauth")
+    public String notauth(HttpSession session){
+        session.setAttribute("msg", "您没有权限请联系管理员");
+        return "login";
+    }
+
+
+}

--- a/src/main/java/cn/lanhuhebi/elderly_group/dao/RoleDao.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/dao/RoleDao.java
@@ -1,9 +1,11 @@
 package cn.lanhuhebi.elderly_group.dao;
 
+import cn.lanhuhebi.elderly_group.model.pojo.Auth;
 import cn.lanhuhebi.elderly_group.model.pojo.Role;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
+import java.util.Set;
 
 public interface RoleDao {
     /**
@@ -18,4 +20,58 @@ public interface RoleDao {
      * @return
      */
     Role getRole(@Param("roleId")Integer roleId);
+
+    /**
+     * 新增角色
+     * @param roleName
+     * @return
+     */
+    int addRole(@Param("roleName")String roleName);
+
+    /**
+     * 根据角色名查询一条数据
+     * @param roleName
+     * @return
+     */
+    Role getRoleByroleName(@Param("roleName")String roleName);
+
+    /**
+     * 查询所有角色的权限
+     * @return
+     */
+    List<Role> getAuths();
+
+    /**
+     * 根据id查询一个角色的菜单权限
+     */
+    List<Auth> getAuthByRoleID(@Param("rlId")Integer rlId);
+
+    /**
+     *  根据角色id查询一个角色的所有权限，菜单及权限分配
+     */
+    List<Auth> getSysRoleAuthByRoleId(@Param("rlId")Integer rlId);
+
+    /**
+     * 批量添加用户权限
+     * @param collection
+     * @return
+     */
+    int addAuthsByRoleId(Set<Integer> collection,@Param("roleId")Integer roleId);
+
+    /**
+     * 批量删除用户权限
+     * @param collection
+     * @param roleId
+     * @return
+     */
+    int deleteAuthsByRoleId(Set<Integer> collection,@Param("roleId")Integer roleId);
+
+    /**
+     * 查询角色下是否重复
+     * @param roleId
+     * @return
+     */
+    Set<Integer> repeatSysRoleAuthByRoleId(@Param("roleId")Integer roleId);
+
+
 }

--- a/src/main/java/cn/lanhuhebi/elderly_group/model/dto/RoleListVo.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/model/dto/RoleListVo.java
@@ -1,0 +1,52 @@
+package cn.lanhuhebi.elderly_group.model.dto;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RoleListVo implements Serializable {
+    //角色Id
+    private Integer rlId;
+    //角色名称
+    private String rlName;
+    //客户端菜单
+    private List<String> clientMenu = new ArrayList<>();
+    //移动端菜单
+    private List<String> mobileMenu = new ArrayList<>();
+
+    public Integer getRlId() {
+        return rlId;
+    }
+
+    public RoleListVo setRlId(Integer rlId) {
+        this.rlId = rlId;
+        return this;
+    }
+
+    public String getRlName() {
+        return rlName;
+    }
+
+    public RoleListVo setRlName(String rlName) {
+        this.rlName = rlName;
+        return this;
+    }
+
+    public List<String> getClientMenu() {
+        return clientMenu;
+    }
+
+    public RoleListVo setClientMenu(List<String> clientMenu) {
+        this.clientMenu = clientMenu;
+        return this;
+    }
+
+    public List<String> getMobileMenu() {
+        return mobileMenu;
+    }
+
+    public RoleListVo setMobileMenu(List<String> mobileMenu) {
+        this.mobileMenu = mobileMenu;
+        return this;
+    }
+}

--- a/src/main/java/cn/lanhuhebi/elderly_group/model/pojo/Auth.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/model/pojo/Auth.java
@@ -16,6 +16,28 @@ public class Auth {
 
     //权限类型
     private Integer authType;
+    //权限平台  1、PC端 2、移动端
+    private Integer authDuan;
+    //上级菜单
+    private Integer authModel;
+
+    public Integer getAuthDuan() {
+        return authDuan;
+    }
+
+    public Auth setAuthDuan(Integer authDuan) {
+        this.authDuan = authDuan;
+        return this;
+    }
+
+    public Integer getAuthModel() {
+        return authModel;
+    }
+
+    public Auth setAuthModel(Integer authModel) {
+        this.authModel = authModel;
+        return this;
+    }
 
     //get set 方法
     public Auth setAuthId (Integer authId){

--- a/src/main/java/cn/lanhuhebi/elderly_group/model/pojo/Role.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/model/pojo/Role.java
@@ -1,5 +1,7 @@
 package cn.lanhuhebi.elderly_group.model.pojo;
 
+import java.util.List;
+
 /**
  * @ClassName Role
  * @Author Oblivion
@@ -13,6 +15,17 @@ public class Role {
 
     //角色名称
     private String roleName;
+
+    private List<Auth> listAuth;
+
+    public List<Auth> getListAuth() {
+        return listAuth;
+    }
+
+    public Role setListAuth(List<Auth> listAuth) {
+        this.listAuth = listAuth;
+        return this;
+    }
 
     //get set 方法
     public Role setRoleId (Integer roleId){

--- a/src/main/java/cn/lanhuhebi/elderly_group/service/RoleService.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/service/RoleService.java
@@ -1,9 +1,12 @@
 package cn.lanhuhebi.elderly_group.service;
 
+import cn.lanhuhebi.elderly_group.model.dto.RoleListVo;
+import cn.lanhuhebi.elderly_group.model.pojo.Auth;
 import cn.lanhuhebi.elderly_group.model.pojo.Role;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
+import java.util.Set;
 
 public interface RoleService {
 
@@ -19,4 +22,48 @@ public interface RoleService {
      * @return
      */
     Role getRole(@Param("roleId")Integer roleId);
+
+    /**
+     * 新增角色
+     * @param roleName
+     * @return
+     */
+    boolean addRole(String roleName);
+
+
+    /**
+     * 根据角色名查询一条数据
+     * @param roleName
+     * @return
+     */
+    boolean getRoleByroleName(String roleName);
+
+    /**
+     * 进入角色列表展示视图
+     * @return
+     */
+    List<RoleListVo> getListRoleAndAuth();
+
+
+    /**
+     *  根据角色id查询一个角色的所有权限，菜单及权限分配
+     */
+    List<Auth> getSysRoleAuthByRoleId(Integer rlId);
+
+    /**
+     * 修改用户角色权限
+     * @param authId
+     * @param roleId
+     * @return
+     */
+    Integer[] updateAUthsByRoleId(Set<Integer> authId, Integer roleId);
+
+
+    /**
+     * 查询角色权限用于权限认证
+     * @param roleId
+     * @return
+     */
+    Set<String> addStringPermissions(Integer roleId);
+
 }

--- a/src/main/java/cn/lanhuhebi/elderly_group/service/impl/RoleServiceImpl.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/service/impl/RoleServiceImpl.java
@@ -1,13 +1,19 @@
 package cn.lanhuhebi.elderly_group.service.impl;
 
 import cn.lanhuhebi.elderly_group.dao.RoleDao;
+import cn.lanhuhebi.elderly_group.model.dto.RoleListVo;
+import cn.lanhuhebi.elderly_group.model.pojo.Auth;
 import cn.lanhuhebi.elderly_group.model.pojo.Role;
 import cn.lanhuhebi.elderly_group.service.RoleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-@Service
+import java.util.Set;
+
+@Service("RoleServiceImpl")
 public class RoleServiceImpl implements RoleService {
     @Autowired
     private RoleDao roleDao;
@@ -20,4 +26,84 @@ public class RoleServiceImpl implements RoleService {
     public Role getRole(Integer roleId) {
         return roleDao.getRole(roleId);
     }
+
+    @Override
+    public boolean addRole(String roleName) {
+        return roleDao.addRole(roleName)>0;
+    }
+
+    @Override
+    public boolean getRoleByroleName(String roleName) {
+        return roleDao.getRoleByroleName(roleName)!=null;
+    }
+
+    @Override
+    public List<RoleListVo> getListRoleAndAuth() {
+        List<RoleListVo> roleListVos = new ArrayList<>();
+        List<Role> listRoles = getListRoles();
+        for(Role r :listRoles){
+            RoleListVo  roles = new RoleListVo();
+            roles.setRlName(r.getRoleName());
+            roles.setRlId(r.getRoleId());
+            List<Auth> authByRole = roleDao.getAuthByRoleID(r.getRoleId());
+            for(Auth a:authByRole){
+                if(a.getAuthDuan()==2){
+                    roles.getMobileMenu().add(a.getAuthName());
+                }else {
+                    roles.getClientMenu().add(a.getAuthName());
+                }
+            }
+            roleListVos.add(roles);
+
+        }
+        return roleListVos;
+    }
+
+    @Override
+    public List<Auth> getSysRoleAuthByRoleId(Integer rlId) {
+        return roleDao.getSysRoleAuthByRoleId(rlId);
+    }
+
+    @Override
+    public Integer[] updateAUthsByRoleId(Set<Integer> authId, Integer roleId) {
+        Integer[] msg = new Integer[2];
+        Set<Integer> repeat = roleDao.repeatSysRoleAuthByRoleId(roleId);
+        Set<Integer> calculation = new HashSet<>();
+
+        //需要添加的数据，数据库没有的
+        calculation.clear();
+        calculation.addAll(authId);
+        calculation.removeAll(repeat);
+        if(calculation.size()>0){
+            //新增成功多少条
+            msg[0] = roleDao.addAuthsByRoleId(calculation, roleId);
+        }else{
+            msg[0] = 0;
+        }
+        //需要删除的数据，
+        calculation.clear();
+        calculation.addAll(repeat);
+        calculation.removeAll(authId);
+        if(calculation.size()>0){
+            //删除成功多少条
+            msg[1] = roleDao.deleteAuthsByRoleId(calculation, roleId);
+        }else{
+            msg[1] = 0;
+        }
+
+
+
+        return msg;
+    }
+
+    @Override
+    public Set<String> addStringPermissions(Integer roleId) {
+        Set<Integer> integers = roleDao.repeatSysRoleAuthByRoleId(roleId);
+        Set<String> strings = new HashSet<>();
+        for(int i: integers){
+            strings.add(String.valueOf(i));
+        }
+        return strings;
+    }
+
 }

--- a/src/main/java/cn/lanhuhebi/elderly_group/util/MyException.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/util/MyException.java
@@ -1,0 +1,20 @@
+package cn.lanhuhebi.elderly_group.util;
+
+import org.apache.shiro.authz.UnauthorizedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * 用来捕获 没有权限异常 并重定向Url
+ */
+@ControllerAdvice
+public class MyException {
+   @ExceptionHandler(value = UnauthorizedException.class)
+    public void defaultErrorHandler(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.sendRedirect("/notauth");
+    }
+}

--- a/src/main/java/cn/lanhuhebi/elderly_group/util/MyRealm.java
+++ b/src/main/java/cn/lanhuhebi/elderly_group/util/MyRealm.java
@@ -1,20 +1,40 @@
 package cn.lanhuhebi.elderly_group.util;
 
 import cn.lanhuhebi.elderly_group.model.pojo.Personnel;
+import cn.lanhuhebi.elderly_group.model.pojo.Role;
 import cn.lanhuhebi.elderly_group.service.PersonnelService;
+import cn.lanhuhebi.elderly_group.service.RoleService;
 import cn.lanhuhebi.elderly_group.service.impl.PersonnelServiceImpl;
+import cn.lanhuhebi.elderly_group.service.impl.RoleServiceImpl;
 import org.apache.shiro.authc.*;
 import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.authz.SimpleAuthorizationInfo;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
+
+import java.util.Set;
 
 public class MyRealm extends AuthorizingRealm  {
 
     private PersonnelService personnelService;
+    private RoleService roleService;
 
-    @Override//权限认证的方法，暂时未写
+    @Override//权限认证的方法
     protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principalCollection) {
-        return null;
+        roleService = (RoleServiceImpl)ApplicationContextHelper.getBean("RoleServiceImpl");
+        //获取当前用户
+        Personnel personnel =   (Personnel)principalCollection.getPrimaryPrincipal();
+        //查询出当前用户的所有权限
+        Set<String> strings = roleService.addStringPermissions(personnel.getPreRoleId());
+        //获得用户角色
+        Role role = roleService.getRole(personnel.getPreRoleId());
+        //通过SimpleAuthenticationInfo做授权
+        SimpleAuthorizationInfo simpleAuthorizationInfo=new SimpleAuthorizationInfo();
+        //添加角色
+        simpleAuthorizationInfo.addRole(String.valueOf(role.getRoleId()));
+        //添加权限
+        simpleAuthorizationInfo.addStringPermissions(strings);
+        return simpleAuthorizationInfo;
     }
 
     @Override //登录的处理方法
@@ -30,6 +50,8 @@ public class MyRealm extends AuthorizingRealm  {
         //判断用户是否为空
         if(null == personnel){
             return null;
+        }else if(personnel.getPreStatus()==0){
+            throw new AuthenticationException("账号被禁用,请联系管理员");
         }else{
             //将对象，对象密码，和这个shiro内的唯一名字交给simpleAuthenticationInfo对象
             SimpleAuthenticationInfo simpleAuthenticationInfo = new SimpleAuthenticationInfo(personnel,personnel.getPrePassword(),getName());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,11 +14,3 @@ mybatis.configuration.log-impl=org.apache.ibatis.logging.stdout.StdOutImpl
 mybatis.type-aliases-package=cn.lanhuhebi.elderly_group.model
 #\u8BBE\u7F6Efreemarker\u9875\u9762 \u53EF\u4EE5\u4F20\u9012\u7A7A\u503C
 spring.freemarker.settings.classic_compatible=true
-
-
-
-
-
-
-
-

--- a/src/main/resources/mappers/RoleMapper.xml
+++ b/src/main/resources/mappers/RoleMapper.xml
@@ -12,13 +12,75 @@
     </select>
 
     <select id="getRole"  resultMap="role" >
-        select  <include refid="rol"/> from role where role_id = #{roleId}
+        select  <include refid="rol"/> from role where role_id = #{roleId} limit 1
     </select>
+
+    <select id="getRoleByroleName"  resultMap="role" >
+        select  <include refid="rol"/> from role where role_name = #{roleName} limit 1
+    </select>
+
+    <insert id="addRole">
+        insert into role set role_name = #{roleName}
+    </insert>
+    
+    <select id="getAuthByRoleID" resultMap="auth">
+      SELECT sr.`role_id`,a.auth_id,a.`auth_name`,a.`auth_type`,a.`auth_duan`,a.`auth_model`
+              FROM sys_role_auth sr,auth a  WHERE  sr.`auth_id`=a.`auth_id`
+                AND sr.`role_id` = #{rlId} and a.auth_type = 1
+    </select>
+
+    <select id="getSysRoleAuthByRoleId" resultMap="auth">
+        SELECT a.`auth_id`,a.`auth_name`,a.`auth_type`,a.`auth_duan`,a.`auth_duan` FROM
+            sys_role_auth sr INNER JOIN auth a ON sr.`auth_id`=a.`auth_id`
+                WHERE role_id = #{rlId}
+    </select>
+
+
+    <insert id="addAuthsByRoleId" parameterType="java.util.Set" >
+        insert into sys_role_auth(role_id,auth_id)values
+        <foreach collection="collection" item="item" separator="," index="index">
+            (#{roleId},#{item})
+        </foreach>
+    </insert>
+
+    <delete id="deleteAuthsByRoleId" parameterType="java.util.Set">
+        delete from sys_role_auth where role_id=#{roleId} and auth_id in
+        <foreach collection="collection" item="item" open="(" separator="," close=")">
+               #{item}
+        </foreach>
+    </delete>
+
+
+
+    <select id="repeatSysRoleAuthByRoleId" resultType="int" >
+         SELECT auth_id FROM sys_role_auth WHERE role_id =#{roleId}
+    </select>
+
+
+
+
 
 
     <resultMap id="role" type="Role" >
         <id property="roleId" column="role_id"/>
         <result property="roleName" column="role_name" />
+        <collection property="listAuth"  ofType="Auth" resultMap="auth"/>
     </resultMap>
+    
+    <resultMap id="auth" type="Auth">
+        <id column="auth_id" property="authId"/>
+        <result column="auth_name" property="authName"/>
+        <result column="auth_type" property="authType"/>
+        <result column="auth_duan" property="authDuan"/>
+        <result column="auth_model" property="authModel"/>
+    </resultMap>
+
+    <resultMap id="sysRoleAuth" type="SysRoleAuth">
+        <result column="role_id" property="roleId"/>
+        <result column="auth_id" property="authId"/>
+    </resultMap>
+
+
+
 
 </mapper>

--- a/src/main/resources/templates/index.ftl
+++ b/src/main/resources/templates/index.ftl
@@ -294,7 +294,7 @@
                                 <!--</li>-->
                             <!--</ul>-->
                         <!--</li>-->
-                        <li><a class="J_menuItem" href="buttons.html">角色列表</a>
+                        <li><a class="J_menuItem" href="/tolistrole">角色列表</a>
                         </li>
                         <!--<li><a class="J_menuItem" href="tabs_panels.html">选项卡 &amp; 面板</a>-->
                         <!--</li>-->

--- a/src/main/resources/templates/role/auth.ftl
+++ b/src/main/resources/templates/role/auth.ftl
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 
-    <title>鹤壁工程系统 - 登录</title>
+    <title>测试权限- 登录</title>
     <meta name="keywords" content="H+后台主题,后台bootstrap框架,会员中心主题,后台HTML,响应式后台">
     <meta name="description" content="H+是一个完全响应式，基于Bootstrap3最新版本开发的扁平化主题，她采用了主流的左右两栏式布局，使用了Html5+CSS3等现代技术">
 
@@ -32,9 +32,9 @@
                 <h1 class="logo-name">H+</h1>
 
             </div>
-            <h3>欢迎使用鹤壁工程系统</h3>
+            <h3>测试权限登录</h3>
 
-            <form class="m-t" role="form" id="formOne" action="/doLogin" method="post">
+            <form class="m-t" role="form" id="formOne" action="/doAuth" method="post">
                 <div class="form-group">
                     <input type="input" id="account"  class="form-control" name="account" placeholder="请输入正确的手机号或邮箱" pattern="(\w[-\w.+]*@([A-Za-z0-9][-A-Za-z0-9]+\.)+[A-Za-z]{2,14})|(0?(13|14|15|18|17)[0-9]{9})" required="">
                 </div>
@@ -42,8 +42,7 @@
                     <input type="password" name="password" class="form-control" placeholder="密码" required="">
                 </div>
                 <#if "msg??"><p class="text-muted text-center"><small style="color: red">${msg}</small></p></#if>
-                <button type="submit" name="login" class="btn btn-primary block full-width m-b">登 录</button>
-                <a href="/test">去测试权限页面</a>
+                <button type="submit" name="login" class="btn btn-primary block full-width m-b">登录测试权限页面</button>
             </form>
         </div>
     </div>

--- a/src/main/resources/templates/role/listrole.ftl
+++ b/src/main/resources/templates/role/listrole.ftl
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+
+<head>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+
+    <title>角色列表</title>
+    <meta name="keywords" content="H+后台主题,后台bootstrap框架,会员中心主题,后台HTML,响应式后台">
+    <meta name="description" content="H+是一个完全响应式，基于Bootstrap3最新版本开发的扁平化主题，她采用了主流的左右两栏式布局，使用了Html5+CSS3等现代技术">
+
+    <link rel="shortcut icon" href="favicon.ico"> <link href="css/bootstrap.min.css?v=3.3.6" rel="stylesheet">
+    <link href="css/font-awesome.css?v=4.4.0" rel="stylesheet">
+
+    <!-- Data Tables -->
+    <link href="css/plugins/dataTables/dataTables.bootstrap.css" rel="stylesheet">
+
+    <link href="css/animate.css" rel="stylesheet">
+    <link href="css/style.css?v=4.1.0" rel="stylesheet">
+
+
+</head>
+
+<body class="gray-bg">
+    <div class="wrapper wrapper-content animated fadeInRight">
+        <div class="col-sm-4">
+            <div class="ibox float-e-margins">
+                <div class="ibox-title">
+                    <h1>角色 <small>列表</small></h1>
+                    <#if "addmsg??">
+                        <p style="color:blue;">${addmsg}</p>
+                    </#if>
+
+                      <#if "addauthmsg??">
+                        <h3>角色:${rlName}</h3>
+                        <p style="color:blue;">新增${addauthmsg}个权限</p>
+                          <p style="color:red;">删除${delauthmsg}个权限</p>
+                      </#if>
+                </div>
+                <div class="ibox-content">
+                    <div class="text-left">
+                        <a data-toggle="modal"  class="btn btn-primary" href="#modal-form">新增角色</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-12">
+                <div class="ibox float-e-margins">
+                    <div class="ibox-title">
+                        <h5>系统管理/<small>角色列表</small></h5>
+                    </div>
+                    <div class="ibox-content">
+
+                        <table class="table table-striped table-bordered table-hover dataTables-example">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>角色名</th>
+                                    <th>显示菜单</th>
+                                    <th>管理端菜单</th>
+                                    <th>操作</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            <#list roles as role >
+                            <tr class="gradeX">
+                                <td>${role.rlId}</td>
+                                <td>${role.rlName}</td>
+                                <td>
+                                    <span style="color: rebeccapurple;">
+                                        <#if role.mobileMenu??&&(role.mobileMenu?size>0)>
+                                            <#assign var = 0/>
+                                             <#list role.mobileMenu as m  >
+                                                <#if var % 4 = 0>
+                                                    <br>
+                                                </#if>
+                                                 ${m}
+                                                 <#assign var = var + 1/>
+                                             </#list>
+                                            <#else >
+                                              无
+                                        </#if>
+                                    </span>
+                                </td>
+                                <td>
+                                     <span style="color: blue">
+                                    <#if role.clientMenu??&&(role.clientMenu?size>0)>
+                                          <#assign var = 0/>
+                                         <#list role.clientMenu as c >
+                                             <#if var % 4 = 0>
+                                                    <br>
+                                             </#if>
+                                                ${c}
+                                             <#assign var = var + 1/>
+                                         </#list>
+                                        <#else >
+                                         无
+                                    </#if>
+                                    </span>
+                                </td>
+                                <td class="center">
+                                    <a data-toggle="modal"  class="btn btn-info btn-xs" href="#">编辑</a>
+                                   &nbsp;&nbsp;&nbsp;<a data-toggle="modal"  class="btn btn-info btn-xs" href="/toUpdateAuth?rlId=${role.rlId}&rlName=${role.rlName}">菜单及权限配置</a>
+                                </td>
+                            </tr>
+                            </#list>
+
+                            </tbody>
+                            <tfoot>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>角色名</th>
+                                    <th>显示菜单</th>
+                                    <th>管理端菜单</th>
+                                    <th>操作</th>
+                                </tr>
+                            </tfoot>
+                        </table>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </div>
+    <div id="modal-form" class="modal fade" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-body">
+                    <h1>新增角色</h1>
+                </div>
+                <div class="ibox-content">
+                    <form class="form-horizontal m-t" id="commentForm" action="/doAddRole" method="post">
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label"><span style="color: red">*</span>角色名称：</label>
+                            <div class="col-sm-8">
+                                <input name="roleName" minlength="2" placeholder="请输入中文名称" type="text" class="form-control" pattern="^[\u4e00-\u9fa5]{0,}$" required="" aria-required="true">
+                            </div>
+                        </div>
+                        <p align="center"  style="color: red" id="preRoleName"></p>
+                        <div class="form-group">
+                            <div class="col-sm-4 col-sm-offset-3">
+                                <button class="btn btn-primary" type="submit">提交</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+    <!-- 全局js -->
+    <script src="js/jquery.min.js?v=2.1.4"></script>
+    <script src="js/bootstrap.min.js?v=3.3.6"></script>
+    <script type="text/javascript">
+        $(function(){
+            $("input[name='roleName']").blur(function () {
+               var roleName = $("input[name='roleName']").val();
+                $("#preRoleName").html('');
+                if(roleName!=null && roleName!=''){
+                    $.post("/ajaxGetRoleByRoleName",{"roleName":roleName},function (flag) {
+                        if(flag){
+                            $("#preRoleName").append("系统内已存在相同的角色");
+                            $("input[name='roleName']").val('');
+                        }else{
+                            $("#preRoleName").append("角色名可以使用");
+                        }
+                    })
+                }
+            })
+        })
+    </script>
+
+    <script src="js/plugins/jeditable/jquery.jeditable.js"></script>
+
+    <!-- Data Tables -->
+    <script src="js/plugins/dataTables/jquery.dataTables.js"></script>
+    <script src="js/plugins/dataTables/dataTables.bootstrap.js"></script>
+
+    <!-- 自定义js -->
+    <script src="js/content.js?v=1.0.0"></script>
+
+
+    <!-- Page-Level Scripts -->
+    <script>
+        $(document).ready(function () {
+            $('.dataTables-example').dataTable();
+
+            /* Init DataTables */
+            var oTable = $('#editable').dataTable();
+
+            /* Apply the jEditable handlers to the table */
+            oTable.$('td').editable('../example_ajax.php', {
+                "callback": function (sValue, y) {
+                    var aPos = oTable.fnGetPosition(this);
+                    oTable.fnUpdate(sValue, aPos[0], aPos[1]);
+                },
+                "submitdata": function (value, settings) {
+                    return {
+                        "row_id": this.parentNode.getAttribute('id'),
+                        "column": oTable.fnGetPosition(this)[2]
+                    };
+                },
+
+                "width": "90%",
+                "height": "100%"
+            });
+
+
+        });
+
+        function fnClickAddRow() {
+            $('#editable').dataTable().fnAddData([
+                "Custom row",
+                "New row",
+                "New row",
+                "New row",
+                "New row"]);
+
+        }
+    </script>
+
+    <script type="text/javascript" src="http://tajs.qq.com/stats?sId=9051096" charset="UTF-8"></script>
+    <!--统计代码，可删除-->
+
+</body>
+
+</html>

--- a/src/main/resources/templates/role/updateAuth.ftl
+++ b/src/main/resources/templates/role/updateAuth.ftl
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+
+<head>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+
+    <title>权限及菜单配置</title>
+    <meta name="keywords" content="H+后台主题,后台bootstrap框架,会员中心主题,后台HTML,响应式后台">
+    <meta name="description" content="H+是一个完全响应式，基于Bootstrap3最新版本开发的扁平化主题，她采用了主流的左右两栏式布局，使用了Html5+CSS3等现代技术">
+
+    <link rel="shortcut icon" href="/favicon.ico"> <link href="/css/bootstrap.min.css?v=3.3.6" rel="stylesheet">
+    <link href="/css/font-awesome.css?v=4.4.0" rel="stylesheet">
+    <link href="/css/animate.css" rel="stylesheet">
+    <link href="/css/style.css?v=4.1.0" rel="stylesheet">
+
+    <link href="css/plugins/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.css" rel="stylesheet">
+
+</head>
+<style>
+
+    table {
+            line-height: 2em;
+            border-collapse: collapse;
+         }
+     thead tr {
+               color: #ae1212;
+               border-bottom: 2px solid #980000;
+           }
+     tbody tr {
+                color: #bd3030;
+                border-bottom: 1px solid #ffaeae;
+            }
+     th {
+                font-weight: normal;
+                text-align: left;
+            }
+     th,td {
+                padding: 0 10px;
+            }
+
+</style>
+
+<body class="gray-bg">
+    <div class="wrapper wrapper-content animated fadeInRight">
+        <div class="row">
+            <div class="col-sm-12">
+                <div class="ibox float-e-margins">
+                    <div class="ibox-title">
+                        <h1>系统管理/ <small>菜单及权限配置</small></h1>
+                    </div>
+                    <div class="ibox-content">
+                        <div class="ibox-title">
+                            <h1>当前角色：${rlName}</h1>
+                            <h3 style="color: red">请选择操作后！务必选中模块以及菜单！！否则权限无效</h3>
+                        </div>
+                            <form method="post" class="form-horizontal" id="doUpdateAuth" action="/doUpdateAuth">
+                                <input type="hidden" name="roleId" value="${rlId}">
+                                <input type="hidden" name="rlName" value="${rlName}">
+                                <div class="hr-line-dashed" align="center"></div>
+                                <table align="center" width="95%">
+
+                                    <tr align="center">
+                                        <th align="center" width="20%"><h1>模块</h1></th>
+                                        <th align="center" width="40%"><h1>菜单</h1></th>
+                                        <th align="center" width="40%"><h1>操作</h1></th>
+                                    </tr>
+
+                                    <tr>
+                                        <td rowspan="11" style="font-size: 30px" align="center">
+                                            移动端<label class="checkbox-primary">
+                                            <input type="checkbox" name="authId" value="52"></label></td>
+                                        <td>
+                                                <div class="col-sm-10">
+                                                    <label class="checkbox-primary">
+                                                        <input type="checkbox" name="authId" value="1">户信息</label>
+                                                </div>
+                                        </td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="2">编辑</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="3">修改</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="4">查看</label>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="5">新增户</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                        </td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="6">出库</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="21">出库</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="7">查看</label>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="8">设备</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="9">入库</label>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="10">分配</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="11">分配</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="12">查看</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="13">修改</label>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="14">安装</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="15">安装</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="16">查看</label>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="17">区域统计</label>
+                                            </div>
+                                        </td><td>
+
+                                        </td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="18">厂家统计</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                        </td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="19">工程统计</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                        </td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="20">我的</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                        </td>
+                                    </tr>
+                                </table>
+
+                                <br>
+                                <br>
+                                <br>
+                                <table align="center" width="95%">
+
+                                    <tr align="center">
+                                        <th align="center" width="20%"><h1>管理端模块</h1></th>
+                                        <th align="center" width="40%"><h1>菜单</h1></th>
+                                        <th align="center" width="40%"><h1>操作</h1></th>
+                                    </tr>
+
+                                    <tr>
+                                        <td rowspan="2" style="font-size: 15px" align="center">户信息管理
+                                            <label class="checkbox-primary">
+                                                <input type="checkbox" name="authId" value="46"></label></td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="22">户信息列表</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="23">编辑</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="24">删除</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="44">查看</label>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="25">新增户信息</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td style="font-size: 15px" align="center">设备管理
+                                            <label class="checkbox-primary">
+                                                <input type="checkbox" name="authId" value="47"></label></td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="26">设备列表</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="29">新增设备</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="27">入库</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="28">删除</label>
+                                            </div>
+                                        </td>
+                                    </tr>
+
+                                    <tr>
+                                        <td rowspan="3" style="font-size: 15px" align="center">统计
+                                            <label class="checkbox-primary">
+                                                <input type="checkbox" name="authId" value="48"></label></td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="30">区域统计</label>
+                                            </div>
+                                        </td>
+                                        <td></td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="31">工程小组统计</label>
+                                            </div>
+                                        </td>
+                                        <td></td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="32">厂家统计</label>
+                                            </div>
+                                        </td>
+                                        <td></td>
+                                    </tr>
+                                    <tr>
+                                        <td rowspan="2" style="font-size: 15px" align="center">账号管理
+                                            <label class="checkbox-primary">
+                                                <input type="checkbox" name="authId" value="49"></label></td>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="33">账号列表</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="36">新增账户</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="34">编辑</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="35">账户角色分配</label>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="37">角色列表</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="38">菜单及权限配置</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="39">新增角色</label>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td  style="font-size: 15px" align="center">工程小组管理
+                                            <label class="checkbox-primary">
+                                                <input type="checkbox" name="authId" value="50"></label></td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="40">工程小组列表</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="42">新增小组</label>
+                                                <label class="checkbox-primary">
+                                                    <input type="checkbox" name="authId" value="41">编辑</label>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td  style="font-size: 15px" align="center">意见反馈<label class="checkbox-primary">
+                                            <input type="checkbox"  name="authId" value="51"></label>
+                                        </td>
+                                        <td>
+                                            <div class="col-sm-10">
+                                                <label class="checkbox-primary">
+                                                    <input  type="checkbox"  name="authId" value="43">意见反馈列表</label>
+                                            </div>
+                                        </td>
+                                        <td>
+                                        </td>
+                                    </tr>
+                                </table>
+                                <div class="hr-line-dashed"></div>
+                                <div class="form-group">
+                                    <div class="col-sm-4 col-sm-offset-2">
+                                        <button class="btn btn-primary" onclick="up();" type="button">保存内容</button>
+                                        <a class="btn btn-white"  href="/tolistrole">取消</a>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 全局js -->
+    <script src="/js/jquery.min.js?v=2.1.4"></script>
+    <script src="/js/bootstrap.min.js?v=3.3.6"></script>
+    <script>
+        function up(){
+            if($("input[type='checkbox']").is(':checked')){
+                $("#doUpdateAuth").submit();
+            }else {
+                alert("请至少选中一个权限");
+                return  false;
+            }
+        }
+
+    </script>
+    <!-- 自定义js -->
+    <script src="/js/content.js?v=1.0.0"></script>
+
+    <script type="text/javascript">
+        $(function() {
+            var rlId = '${rlId}';
+            //document.getElementById(43).setAttribute("checked","checked");
+            $.post("/ajaxgetSysRoleAuthByRoleId", {"rlId": rlId}, function (s) {
+                        for (var p in s){
+                            var a  = s[p].authId;
+                            $("input[value='"+a+"']").attr("checked","checked");
+                        }
+                    }, "json"
+            );
+        });
+    </script>
+
+    <script type="text/javascript" src="http://tajs.qq.com/stats?sId=9051096" charset="UTF-8"></script>
+    <!--统计代码，可删除-->
+
+</body>
+
+</html>

--- a/src/main/resources/templates/testAuto.ftl
+++ b/src/main/resources/templates/testAuto.ftl
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+<h1 align="center">测试权限页面</h1>
+<h2>页面是templates/testAuto.ftl</h2>
+<h2>---------guest（游客）--一旦登录就不会显示---------</h2>
+<@shiro.guest>
+    您当前是游客，<a href="javascript:void(0);">登录</a>
+</@shiro.guest>
+<h1>-------- user（已经登录，或者记住我登录) ------------</h1>
+<@shiro.user>
+    <p>欢迎[<@shiro.principal/>]</p>
+    <h2><a href="/logout">用户退出</a></h2>
+</@shiro.user>
+<h2>--------hasRole标签（判断是否拥有这个角色）------------</h2>
+<h3> 1=管理员、2=工程组长、3=信息员、4=安装工、5=库管员、6=政府人员、7=运维人员、8=测试、9=测试员</h3>
+<@shiro.hasRole name="1">拥有角色管理员<br/></@shiro.hasRole>
+<@shiro.hasRole name="2">拥有角色工程组长<br/></@shiro.hasRole>
+<@shiro.hasRole name="3">拥有角色信息员<br/></@shiro.hasRole>
+<@shiro.hasRole name="4">拥有角色安装工<br/></@shiro.hasRole>
+<@shiro.hasRole name="5">拥有角色库管员<br/></@shiro.hasRole>
+<@shiro.hasRole name="6">拥有角色政府人员<br/></@shiro.hasRole>
+<@shiro.hasRole name="7">拥有角色运维人员<br/></@shiro.hasRole>
+<@shiro.hasRole name="8">拥有角色测试<br/></@shiro.hasRole>
+<@shiro.hasRole name="9">拥有角色测试员<br/></@shiro.hasRole>
+
+<h2>--------hasAnyRoles标签（判断是否拥有这些角色的其中一个）------------</h2>
+<@shiro.hasAnyRoles name="1,2,3">
+拥有角色:管理员--或--工程组长--或--信息员<br/>
+</@shiro.hasAnyRoles>
+
+
+
+<h2>-------- lacksRole标签（判断是否不拥有这个角色）------------</h2>
+<@shiro.lacksRole name="2">
+    不拥有工程组长角色
+</@shiro.lacksRole>
+
+<h2>--------hasPermission标签（判断是否有拥有这个权限）------------</h2>
+<@shiro.hasPermission name="52">
+   拥有移动端的权限
+</@shiro.hasPermission>
+
+<@shiro.hasPermission name="49">
+   编辑户信息
+</@shiro.hasPermission>
+</body>
+</html>

--- a/src/test/java/cn/lanhuhebi/elderly_group/ElderlyGroupApplicationTests.java
+++ b/src/test/java/cn/lanhuhebi/elderly_group/ElderlyGroupApplicationTests.java
@@ -1,16 +1,61 @@
 package cn.lanhuhebi.elderly_group;
 
+import cn.lanhuhebi.elderly_group.dao.RoleDao;
+import cn.lanhuhebi.elderly_group.service.RoleService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class ElderlyGroupApplicationTests {
+    @Autowired
+    private RoleDao roleDao;
 
+    @Autowired
+    private RoleService roleService;
     @Test
     public void contextLoads() {
+
+        int roleid = 9;
+        Integer[] add = {3,7,8,9,52,20,21,32,17};
+        Set<Integer> shu = roleDao.repeatSysRoleAuthByRoleId(9);
+        Set<Integer> xin =   new HashSet<>(Arrays.asList(add));
+        Set<Integer> qiu = new HashSet<>();
+
+        qiu.clear();
+        qiu.addAll(xin);
+        qiu.removeAll(shu);
+        System.out.println("需要添加的数据= " + qiu);
+        if(qiu.size()>0){
+            int i = roleDao.addAuthsByRoleId(qiu, roleid);
+            if(i>0){
+                System.out.println("添加成功"+i);
+            }else{
+                System.out.println("添加失败");
+            }
+        }
+
+        qiu.clear();
+        qiu.addAll(shu);
+        qiu.removeAll(xin);
+        System.out.println("需要删除的数据="+qiu);
+        if(qiu.size()>0){
+            int i1 = roleDao.deleteAuthsByRoleId(qiu, roleid);
+            if(i1>0){
+                System.out.println("删除成功"+i1);
+            }else{
+                System.out.println("删除失败");
+            }
+        }
+
+
     }
 
 }


### PR DESCRIPTION
（新增角色ajax判断用户名是否重复）
（修改权限，批量新增与修改，并返回新增与修改数量给页面，使用Set集合，保证权限不重复添加）
（修改页面AJax默认选中当前角色权限）
（查询角色权限建立Vo 分为显示菜单与管理端菜单）

修改登录 登录判断是否拥有权限， 登录页面新增去测试shiro标签登录，新增shiro权限认证。
（用户角色是RoleId）
（用户权限是AuthId）
（考虑系统权限赋值问题，暂时系统登录判断用户是否拥有客户端菜单的任何一个权限即可登录成功，否则跳转回登录页面，提示没有权限）
(增加了一个QyyController测试权限的方法,登录成功后，会去testAuth.ftl内显示的是shiro标签的使用场景，）
（暂时只控制了登录权限）